### PR TITLE
Fix memory leak and closeIcon position.

### DIFF
--- a/src/components/ChatEngine/ChatFeed/NewMessageForm/Thumbnail.js
+++ b/src/components/ChatEngine/ChatFeed/NewMessageForm/Thumbnail.js
@@ -1,13 +1,16 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 
 import { CloseCircleTwoTone } from '@ant-design/icons'
 
 const Thumbnail = props => {
     const [hovered, setHovered] = useState(false)
-
+    const [blob, setBlob] = useState('')
+    useEffect(() => {
+      setBlob(URL.createObjectURL(props.file))
+    }, [props.file])
     return (
         <div 
-            style={{ padding: '12px 6px', display: 'inline' }}
+            style={{ padding: '12px 6px', display: 'inline-block', position: "relative" }}
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
         >
@@ -15,7 +18,7 @@ const Thumbnail = props => {
             <img
                 style={styles.imageSquare}
                 alt={props.file ? props.file.name : ''}
-                src={URL.createObjectURL(props.file)}
+                src={blob}
             />
 
             {
@@ -41,9 +44,9 @@ const styles = {
         display: 'inline',
     },
     closeIcon: {
-        position: 'relative', 
-        bottom: '91px', 
-        right: '20px', 
+        position: 'absolute', 
+        bottom: 'calc(100% - 32px)', 
+        left: '96px', 
         width: '0px', 
         cursor: 'pointer'
     }


### PR DESCRIPTION
### Memory Leak.
As the documentation says: "Each time you call createObjectURL(), a new object URL is created, even if you've already created one for the same object." https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL
URL.createObjectURL(props.file) at src attribute will constantly add new object URL. So I added useEffect which depends on props.files and creates 1 object URL. But this is not the best solution and needs some work. For example, when deleting, clicking on closeIcon will change props.file and useEffect will create another object URL for each remaining file. You will need to add URL.revokeObjectURL().
### closeIcon position.
closeIcon position was above attachments and there was no way to remove a single image. It now looks like this:
![result](https://i.imgur.com/5BHTdMq.png "Result image")